### PR TITLE
Fix: binary field truncated at 64 bytes

### DIFF
--- a/msg.reader.js
+++ b/msg.reader.js
@@ -425,8 +425,7 @@
         },
         'binary': function extractBatBinary(ds, msgData, blockStartOffset, bigBlockOffset, blockSize) {
           ds.seek(blockStartOffset + bigBlockOffset);
-          var toReadLength = Math.min(Math.min(msgData.bigBlockSize - bigBlockOffset, blockSize), CONST.MSG.SMALL_BLOCK_SIZE);
-          return ds.readUint8Array(toReadLength);
+          return ds.readUint8Array(blockSize);
         }
       }
     },


### PR DESCRIPTION
Fix bug causing binary fields to be truncated at 64 bytes (i.e. `SMALL_BLOCK_SIZE`.)

This bug affects attempts to extract HTML embedded as binary in `.msg` files.