### PR TITLE
Add example to download each file attachment

### DIFF
--- a/examples/example.html
+++ b/examples/example.html
@@ -141,8 +141,11 @@
                 fileData.body ? fileData.body.substring(0, Math.min(500, fileData.body.length))
                 + (fileData.body.length > 500 ? '...' : '') : '');
             $('.msg-example .msg-attachment').html(jQuery.map(fileData.attachments, function (attachment, i) {
+              var file = msgReader.getAttachment(i);
+              var fileUrl = URL.createObjectURL(new File([file.content], attachment.fileName, {type: "application/octet-stream"}));
               return attachment.fileName + ' [' + attachment.contentLength + 'bytes]' +
-                  (attachment.pidContentId ? '; ID = ' + attachment.pidContentId : '');
+                  (attachment.pidContentId ? '; ID = ' + attachment.pidContentId : '') +
+                  '; <a href="' + fileUrl + '">Download</a>';
             }).join('<br/>'));
             $('.msg-info').show();
 


### PR DESCRIPTION
This change makes the example a bit more clear on how you can interact with the msg file's attachments.

I can provide code for another example that involves loading the msg file from a specified remote url, if anyone think it will be helpful.